### PR TITLE
add a minimum version requirement on JuMP

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.4
 IJulia
 PyPlot
-JuMP
+JuMP 0.13
 Ipopt
 StatsBase
 Dierckx


### PR DESCRIPTION
since you use the at-variable syntax here https://github.com/charlesll/Spectra.jl/blob/789598289a2980d1a3c99de56d92ad38e55558ba/src/baseline.jl#L42

edit: the Travis CI failure on Linux was a pre-existing inability to find matplotlib
