### PR TITLE
Change ## to # in example comments

### DIFF
--- a/docs/src/Measurements.md
+++ b/docs/src/Measurements.md
@@ -17,13 +17,13 @@ We first generate a dummy signal to play with:
 ```@example 1
 using Plots, Spectra, Random
 
-## the x axis
+# the x axis
 x = collect(0:0.1:100)
 
-## a fake signal: perfect y
+# a fake signal: perfect y
 y_perfect = gaussian(x, 1.0, 50.0, 6.0)
 
-## we add noise: observed y
+# we add noise: observed y
 y = y_perfect + 0.05*randn(size(x,1))
 
 plot(x, y, label="Noisy observed signal", xlabel="X", ylabel="Y")

--- a/docs/src/PeakFitting.md
+++ b/docs/src/PeakFitting.md
@@ -38,21 +38,22 @@ using Plots
 using Spectra
 using Statistics
 
-## The X axis
+# The X axis
 x = collect(0:0.2:100)
-## The "perfect" Y signal
+
+# The "perfect" Y signal
 y_perfect = (
     gaussian(x, [10.0, 35.0, 10.0]) +
     lorentzian(x, [15.0, 55.0, 3.0]) +
     pearson7(x, [20.0, 45.0, 2.0, 0.4])
 )
-## Of course, in real world we have noise, here it is Gaussian
+# Of course, in real world we have noise, here it is Gaussian
 noise = randn(length(x))*0.3
 
-## This is what we observe and want to fit
+# This is what we observe and want to fit
 y_obs = y_perfect + noise
 
-## Let's visualize it!
+# Let's visualize it!
 p1 = plot(x, [y_perfect, y_obs]; labels=["The true signal" "Observations"])
 savefig("fit_1.svg"); nothing #hide
 ```
@@ -61,27 +62,27 @@ savefig("fit_1.svg"); nothing #hide
 First, you define a vector containing named vectors of peak types, ``m_{prior}``, ``\sigma_{m_{prior}}``, and lower and upper boundaries. For instance, after a visual review of the signal above, you would declare a vector of peak informations like this:
 
 ```@example 1
+# (peak_type, m_prior, sigma_m_prior, lower_bounds, upper_bounds)
 peaks_info = [
-    ## (peak_type, m_prior, sigma_m_prior, lower_bounds, upper_bounds)
     (   
-        :gaussian, ## peak_type
-        [10.5, 30.0, 11.0], ## m_prior (intensity, position, hwhm)
-        [5.0, 5.0, 3.0], ## sigma_m_prior
-        [0.0, 0.0, 0.0], ## lower_bounds
-        [Inf, Inf, 50.0]), ## upper_bounds
+        :gaussian, # peak_type
+        [10.5, 30.0, 11.0], # m_prior (intensity, position, hwhm)
+        [5.0, 5.0, 3.0], # sigma_m_prior
+        [0.0, 0.0, 0.0], # lower_bounds
+        [Inf, Inf, 50.0]), # upper_bounds
     (
-        :lorentzian, ## peak_type
-        [17.5, 54.0, 3.1], ## m_prior (intensity, position, hwhm)
-        [5.0, 3.0, 1.0], ## sigma_m_prior
-        [0.0, 0.0, 0.0], ## lower_bounds
-        [Inf, Inf, Inf], ## upper_bounds
+        :lorentzian, # peak_type
+        [17.5, 54.0, 3.1], # m_prior (intensity, position, hwhm)
+        [5.0, 3.0, 1.0], # sigma_m_prior
+        [0.0, 0.0, 0.0], # lower_bounds
+        [Inf, Inf, Inf], # upper_bounds
     ),
     (
-        :pearson7, ## peak_type
-        [21.5, 44.0, 3.0, 0.4], ## m_prior (intensity, position, hwhm, shape exponent)
-        [3.0, 2.0, 5.0, 0.02], ## sigma_m_prior
-        [0.0, 0.0, 0.0, 0.0], ## lower_bounds
-        [100.0, 100.0, 50.0, Inf], ## upper_bounds
+        :pearson7, # peak_type
+        [21.5, 44.0, 3.0, 0.4], # m_prior (intensity, position, hwhm, shape exponent)
+        [3.0, 2.0, 5.0, 0.02], # sigma_m_prior
+        [0.0, 0.0, 0.0, 0.0], # lower_bounds
+        [100.0, 100.0, 50.0, Inf], # upper_bounds
     ),
 ]
 ```
@@ -231,34 +232,34 @@ Run it on your own computer! If you have suggestions, do not hesitate!
 ```julia
 using Turing
 
-## Define a Bayesian model with priors
+# Define a Bayesian model with priors
 @model function bayesian_peaks(x, y)
-    ## Define priors based on peak_types
+    # Define priors based on peak_types
 
-    ## PEAK 1
+    # PEAK 1
     amplitude ~ truncated(Normal(10.016, 0.5), 0.0, Inf)
     center ~ Normal(34.92, 0.5)
     width ~ truncated(Normal(10.0, 0.5), 0.0, Inf)
 
     μ = gaussian(x, [amplitude, center, width])
     
-    ## PEAK 2
+    # PEAK 2
     amplitude2 ~ truncated(Normal(14.9, 0.5), 0.0, Inf)
     center2 ~ Normal(55.0, 0.5)
     width2 ~ truncated(Normal(3.0, 0.5), 0.0, Inf)
     
     μ2 = lorentzian(x, [amplitude2, center2, width2])
     
-    ## PEAK 3
+    # PEAK 3
     amplitude3 ~ truncated(Normal(25.5, 0.5), 0.0, Inf)
     center3 ~ Normal(43.0, 10.0)
     width3 ~ truncated(Normal(2.0, 0.5), 0.0, Inf)
     lr ~ truncated(Normal(0.39, 0.03), 0.0, 1.0)
     
-    ## Calculate model prediction
+    # Calculate model prediction
     μ3 = pseudovoigt(x, [amplitude3, center3, width3, lr])
     
-    ## Likelihood
+    # Likelihood
     σ ~ truncated(Normal(0.2, 0.03), 0.001, Inf)
     y ~ MvNormal(μ + μ2 + μ3, σ^2 * I)
 end

--- a/docs/src/PreProcessing.md
+++ b/docs/src/PreProcessing.md
@@ -7,29 +7,29 @@ Spectra allows you to perform several processing steps on x-y spectral data. Bel
 As a starting point and for the sack of example, we create two synthetic signals to play with. They will be Gaussian signals randomly sampled along two different X axis, with noise and increasing backgrounds. One of them will also have a strong spike!
 
 ```@example 1
-## Signal creation
+# Signal creation
 using Spectra, Plots
 
-## we create a fake signal with 
+# we create a fake signal with 
 x_1 = rand(1000)*100
 x_2 = rand(1000)*100
 
-## create a signal that is the combination of two gaussian peaks plus a background
+# create a signal that is the combination of two gaussian peaks plus a background
 background_1 = 0.08 * x_1
 background_2 = 0.03 * x_2
 
-## some noise
+# some noise
 noise_1 = 0.5*randn(1000)
 noise_2 = 0.3*randn(1000)
 
-## the full toy signals
+# the full toy signals
 y_1 = gaussian(x_1, 10.0, 40., 5.) .+ background_1 .+ noise_1
 y_2 = gaussian(x_2, 20.0, 60., 9.) .+ background_2 .+ noise_2
 
-## one of them will have a spike!
+# one of them will have a spike!
 y_1[600] = 250.0 
 
-## make a plot of our two spectra
+# make a plot of our two spectra
 scatter(x_1, y_1)
 scatter!(x_2, y_2)
 savefig("fp_1.svg"); nothing #hide

--- a/docs/src/examples/Raman_spectrum_fitting.md
+++ b/docs/src/examples/Raman_spectrum_fitting.md
@@ -44,14 +44,14 @@ For further references for fitting Raman spectra of glasses, please see for inst
 First, we import the libraries for doing various things:
 
 ````@example Raman_spectrum_fitting
-using Spectra ## our Spectra library
-using Statistics ## to have access to core functions like mean() or std()
-using DelimitedFiles ## to import the data
+using Spectra # our Spectra library
+using Statistics # to have access to core functions like mean() or std()
+using DelimitedFiles # to import the data
 
 # Plotting libraries
-using Plots ## to make plots
-gr() ## Plots backend
-using LaTeXStrings ## LaTeX for superscripts/subscripts in labels, captions...
+using Plots # to make plots
+gr() # Plots backend
+using LaTeXStrings # LaTeX for superscripts/subscripts in labels, captions...
 ````
 
 ## Importing data


### PR DESCRIPTION
Fixes Issue https://github.com/charlesll/Spectra.jl/issues/36.

In the examples in the docs, double hash marks are used frequently in the comments. Double hash marks, ##, create code regions in VS Code such that pressing alt+return will execute code only between the ##. This can cause confusion for people who copy and paste the examples and try to run them (including me). This replaces all ## with a single # in the comments in the documentation.